### PR TITLE
THEOplayer

### DIFF
--- a/theoplayer/index.html
+++ b/theoplayer/index.html
@@ -1,0 +1,3 @@
+<video id="video-player" controls="controls" width="640"
+    src="//cdn.theoplayer.com/video/star_wars_episode_vii-the_force_awakens_official_comic-con_2015_reel_(2015)/index.m3u8"
+    poster="//cdn.theoplayer.com/video/star_wars_episode_vii-the_force_awakens_official_comic-con_2015_reel_(2015)/poster.jpg" />

--- a/theoplayer/playerinfo.json
+++ b/theoplayer/playerinfo.json
@@ -1,0 +1,37 @@
+{
+  "name": "THEOplayer",
+  "version": "1.5.61",
+  "url": "https://www.theoplayer.com/",
+  "description": "THEOplayer is the world's most comprehensive HTML5 based video player for streaming content on the web. THEOplayer offers adaptive streaming of HTTP Live Streaming (also known as HLS) on all modern browsers and devices, without using any plugins. With THEOplayer, video publishers can use a single video player with a single streaming protocol to reach all their viewers, dramatically simplifying online video content distribution. THEOplayer removes the need for plugins such as Flash or Silverlight, providing a better user experience on more platforms and devices. THEOplayer is developed by OpenTelly, a fast-growing SaaS company located in Leuven (Belgium).",
+  "pricing": {
+    "once": false,
+    "subscription": true,
+    "freeAvailable": false
+  },
+  "example": {
+    "jsFoot": "https://cdn.theoplayer.com/latest/be571103-b0c2-4840-86a4-ed581824ca37/theoplayer.loader.js"
+  },
+  "flags": {
+    "library": "",
+    "flash": false,
+    "api": true,
+    "unifiedLook": true,
+    "unifiedAPI": true,
+    "fullscreen": true,
+    "keyboard": true,
+    "subtitles": true,
+    "playlists": true,
+    "responsive": true,
+    "embeddable": false,
+    "cms": [],
+    "services": [],
+    "skinnable": true,
+    "audioOnly": true,
+    "speedControl": true,
+    "qualityControl": true,
+    "hosted": "possible",
+    "aria": false,
+    "hls": true,
+    "dash": true
+  }
+}


### PR DESCRIPTION
We at OpenTelly noticed you noticing our player, so here are some details about THEOplayer for the new video player comparison chart!

The provided example page shows a very minimal setup. THEOplayer automatically detects all `<video>` and `<audio>` tags on the webpage, so you don't even need to write a single line of JavaScript to initialize the player. Of course [you can do a lot more with the player](https://www.theoplayer.com/features.html), as indicated by the `playerinfo.json`.

Since our player is mainly focused on HLS playback, the example uses one of our sample HLS video streams with multiple video qualities and subtitle tracks. The player can also play regular video files (MP4, WebM), if needed we can give an example of that as well.

We currently do not have a free version yet. The provided JavaScript file is licensed for the `praegnanz.de` domain, so you can use it with the given example to showcase the player on your website.

If you have problems with the example or the player information, do let us know in the comments. We're happy to help you out.
