### PR TITLE
add jvideoplayer

### DIFF
--- a/jvideoplayer/index.html
+++ b/jvideoplayer/index.html
@@ -1,0 +1,184 @@
+<style>
+
+    .loaderimage {
+        position: absolute;
+        top: 0;
+        z-index: 500;
+        width: 100%;
+        height: 100%;
+        background-position: center center;
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-attachment: fixed;
+        background-color: black;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+</style>
+<!-- <div class="loaderimage" style="background-image: url(https://peach.blender.org/wp-content/uploads/bbb-splash.png?4323d4)"> -->
+<div class="loaderimage" style="background-image: url({{player.poster}})">
+    <style type='text/css'>@-webkit-keyframes uil-default-anim { 0% { opacity: 1} 100% {opacity: 0} }@keyframes uil-default-anim { 0% { opacity: 1} 100% {opacity: 0} }.uil-default-css > div:nth-of-type(1){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: -0.5s;animation-delay: -0.5s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(2){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: -0.4166666666666667s;animation-delay: -0.4166666666666667s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(3){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: -0.33333333333333337s;animation-delay: -0.33333333333333337s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(4){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: -0.25s;animation-delay: -0.25s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(5){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: -0.16666666666666669s;animation-delay: -0.16666666666666669s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(6){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: -0.08333333333333331s;animation-delay: -0.08333333333333331s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(7){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: 0s;animation-delay: 0s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(8){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: 0.08333333333333337s;animation-delay: 0.08333333333333337s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(9){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: 0.16666666666666663s;animation-delay: 0.16666666666666663s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(10){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: 0.25s;animation-delay: 0.25s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(11){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: 0.33333333333333337s;animation-delay: 0.33333333333333337s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}.uil-default-css > div:nth-of-type(12){-webkit-animation: uil-default-anim 1s linear infinite;animation: uil-default-anim 1s linear infinite;-webkit-animation-delay: 0.41666666666666663s;animation-delay: 0.41666666666666663s;}.uil-default-css { position: relative;background:none;width:200px;height:200px;}</style><div class='uil-default-css' style='transform:scale(0.6);'><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(0deg) translate(0,-60px);transform:rotate(0deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(30deg) translate(0,-60px);transform:rotate(30deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(60deg) translate(0,-60px);transform:rotate(60deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(90deg) translate(0,-60px);transform:rotate(90deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(120deg) translate(0,-60px);transform:rotate(120deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(150deg) translate(0,-60px);transform:rotate(150deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(180deg) translate(0,-60px);transform:rotate(180deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(210deg) translate(0,-60px);transform:rotate(210deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(240deg) translate(0,-60px);transform:rotate(240deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(270deg) translate(0,-60px);transform:rotate(270deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(300deg) translate(0,-60px);transform:rotate(300deg) translate(0,-60px);border-radius:10px;position:absolute;'></div><div style='top:80px;left:93px;width:14px;height:40px;background:#00b2ff;-webkit-transform:rotate(330deg) translate(0,-60px);transform:rotate(330deg) translate(0,-60px);border-radius:10px;position:absolute;'></div></div>
+</div>
+
+
+
+<!-- START PHP INCLUDE templates/jvp.mantis.htpl -->
+<div class="mantis_host">
+
+
+    <div class="videoplayer"></div>
+
+    <div class="player_controls">
+        <section class="timeline">
+            <label class="noselect">00:00:00</label>
+            <div class="scrubber">
+                <div class="progress">
+                    <div class="completed"></div>
+                    <div class="buffered"></div>
+
+                    <div class="mark arrow"></div>
+                    <div class="mark guide"></div>
+                </div>
+                <!-- Note: the handle class has been added to the .target button, because firefox otherwise "doesn't detect" the click on the handle -->
+                <button class="target handle">
+                    <div class="handle"></div>
+                </button>
+                <section class="preview noselect">
+                </section>
+            </div>
+        </section>
+        <section class="control_bar">
+            <div class="control control_play_resume jvp-icon-play"></div>
+            <div class="control control_pause jvp-icon-pause"></div>
+            <div class="control control_volume jvp-icon-volume-high">
+                <div class="menu_wrapper">
+                    <div class="padder">
+                        <div class="scrubber">
+                            <div class="progress">
+                                <div class="completed"></div>
+                            </div>
+                            <!-- Note: the handle class has been added to the .target button, because firefox otherwise "doesn't detect" the click on the handle -->
+                            <button class="target handle vertical">
+                                <div class="handle vertical"></div>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="video_title noselect"><span>Crouching Tiger, Hidden Dragon: Sword of Destiny</span></div>
+            <!--            <div class="control control_config jvp-icon-cog"></div>-->
+            <div class="control control_fullscreen jvp-icon-enlarge"></div>
+        </section>
+        <section class="bubble_bar">
+            <div class="bubble">
+                <label><a href="#">Skip ad</a></label>
+            </div>
+        </section>
+
+
+    </div>
+</div>
+<!-- END PHP INCLUDE templates/jvp.mantis.htpl -->
+
+
+<script>
+
+    (function ($) {
+        $(document).ready(function () {
+
+            var loaderImage = "";
+
+
+            var adsEvents = [
+                {
+                    start: 3 * 60 * 1000,
+                    // original video: https://www.youtube.com/watch?v=kfchvCyHmsc
+                    url: 'https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/prototype/video/late-for-work.mp4',
+                    minplay: 3,
+                },
+            ];
+
+            var cuesEvents = [
+                {
+                    start: 2000,
+                    text: "You could add subtitles here if you wanted to...",
+                    duration: 2000,
+                },
+                {
+                    start: 6000,
+                    text: "...parsing a srt file is an option",
+                    duration: 2500,
+                },
+                {
+                    start: 10000,
+                    text: "There is an ad at 03:00",
+                    duration: 2500,
+                },
+            ];
+
+
+            var jSurface = $('.mantis_host');
+
+
+            var jVideoPlayer = $('> .videoplayer', jSurface);
+
+            var vp = new videoPlayer({
+                element: jVideoPlayer,
+                plugins: [
+                    new pluginRemoveLoaderImage({
+                        img: $('.loaderimage'),
+                    }),
+//                    new pluginDebugHelper({mode: 'triggered', blackList: ["progress", "timeupdate"]}),
+                    new pluginAd({
+                        events: adsEvents,
+                    }),
+                    new pluginAdSkipAdButton({
+                        text: "Skip this ad",
+                    }),
+                    new pluginCue({
+                        events: cuesEvents,
+                    }),
+                    new pluginInactivity({
+                        jHost: jSurface,
+                    }),
+                    new pluginMantis({
+                        mantis: new Mantis(jSurface),
+                        plugins: [
+                            new pluginMantisTimeElapsed(),
+//                            new pluginMantisThumbnailPreview({
+//                                urlFormat: '/video/screenshots/panda1s/img_{n}.png',
+//                                timeInterval: 1,
+//                            }),
+                            new pluginMantisCloneThumbnailPreview(),
+                            new pluginMantisTimelineMark({
+                                marks: adsEvents,
+                            }),
+                            new pluginMantisBackToApp({
+                                jHost: jSurface,
+                                click: function () {
+                                    console.log("clicked");
+                                },
+                                text: "Back to app",
+                            }),
+                        ],
+                    }),
+                ]
+            });
+
+
+            vp.load({
+                url: "http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_720p_h264.mov",
+                url: "{{player.video.mp4}}",
+                title: "Big Buck Bunny",
+                title: "Your video title",
+            }, function () {
+                vp.resume();
+            });
+
+        });
+    })(jQuery);
+
+</script>
+

--- a/jvideoplayer/playerinfo.json
+++ b/jvideoplayer/playerinfo.json
@@ -1,0 +1,67 @@
+{
+  "name": "jvideoplayer",
+  "version": "1.1.0",
+  "url": "https://github.com/lingtalfi/jVideoPlayer",
+  "description": "A javascript library to help building a video player.",
+  "repository": "https://github.com/lingtalfi/jVideoPlayer",
+  "license": "none",
+  "pricing": {
+    "once": false,
+    "subscription": false,
+    "freeAvailable": true
+  },
+  "library": ["jquery"],
+  "hosted": false,
+
+  "example": {
+    "css": [
+    	"https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/layered-manager/layered-manager.css",
+    	"https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/mantis/plugin.mantis.backtoapp.css",
+    	"https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/remote/mantis/style.css"
+    ],
+    "jsHead": [
+      "http://code.jquery.com/jquery-2.2.2.min.js", 
+      "https://cdn.rawgit.com/lingtalfi/JFullScreen/master/www/libs/jfullscreen/js/jfullscreen.js", 
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/js/video-element/html5-video-element.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/js/eventsqueue/eventsqueue.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/layered-manager/layered-manager.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/video-player.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/plugin.removeloaderimage.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/plugin.debughelper.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/ad/plugin.ad.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/ad/plugin.ad.skipadbutton.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/plugin.cue.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/plugin.inactivity.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/mantis/plugin.mantis.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/mantis/plugin.mantis.timeelapsed.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/mantis/plugin.mantis.clonethumbnailpreview.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/mantis/plugin.mantis.timelinemark.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/video-player/plugin/mantis/plugin.mantis.backtoapp.js",
+      "https://cdn.rawgit.com/lingtalfi/jDragSlider/master/www/libs/jdragslider/js/jdragslider.js",
+      "https://cdn.rawgit.com/lingtalfi/VSwitch/master/www/libs/vswitch/js/vswitch.js",
+      "https://cdn.rawgit.com/lingtalfi/jVideoPlayer/master/www/libs/jvideoplayer/widget/remote/mantis/mantis.js"
+      ]
+  },
+
+  "flags": {
+    "flash": false,
+    "api": true,
+    "unifiedAPI": true,
+    "fullscreen": true,
+    "keyboard": false,
+    "subtitles": true,
+    "chapters": false,
+    "playlists": false,
+    "responsive": true,
+    "embeddable": false,
+    "cms": [],
+    "services": "",
+    "skinnable": true,
+    "audioOnly": false,
+    "speedControl": false,
+    "qualityControl": false,
+    "aria": false,
+    "hls": false,
+    "dash": false
+  }
+}


### PR DESCRIPTION
Notes:

to demonstrate the ad management feature, I added my own add video in the html code. 

The same for subtitles.
I saw that you guys have tags for tags source files,
but the current version of my player use a subtitles js array.

If php were enabled, I could use a .srt file, but php is not enabled,
so as I want to showcase the subtitles features of the player,
I added them manually.

Other tags I would suggest, based on my player's possibilities, are:
- videoTitle: which is displayed inside the remote controller
  
  ```
      (there is a code pen here: http://codepen.io/lingtalfi/pen/aNwbJy)
  ```
- adUrl0: the url of an advertising video
- adUrl1: the url of an other advertising video
